### PR TITLE
PR #112 vector parameters

### DIFF
--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -386,15 +386,15 @@ def Pulsar(*args, **kwargs):
     timing_package = kwargs.get('timing_package', 'tempo2')
 
     if pint:
-        toas     = list(filter(lambda x: isinstance(x, toa.TOAs), args))
-        model    = list(filter(lambda x: isinstance(x, TimingModel), args))
+        toas = list(filter(lambda x: isinstance(x, toa.TOAs), args))
+        model = list(filter(lambda x: isinstance(x, TimingModel), args))
 
     t2pulsar = list(filter(lambda x: isinstance(x, t2.tempopulsar), args))
-    
-    parfile  = list(filter(lambda x: isinstance(x, str) and
-                           x.split('.')[-1] == 'par', args))
-    timfile  = list(filter(lambda x: isinstance(x, str) and
-                           x.split('.')[-1] in ['tim', 'toa'], args))
+
+    parfile = list(filter(lambda x: isinstance(x, str) and
+                          x.split('.')[-1] == 'par', args))
+    timfile = list(filter(lambda x: isinstance(x, str) and
+                          x.split('.')[-1] in ['tim', 'toa'], args))
 
     if pint and toas and model:
         return PintPulsar(toas[0], model[0], sort=sort, planets=planets)

--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -423,7 +423,7 @@ def Pulsar(*args, **kwargs):
         elif timing_package.lower() == 'tempo2':
 
             # hack to set maxobs
-            maxobs = get_maxobs(reltimfile)
+            maxobs = get_maxobs(reltimfile) + 100
             t2pulsar = t2.tempopulsar(relparfile, reltimfile,
                                       maxobs=maxobs, ephem=ephem)
             os.chdir(cwd)

--- a/enterprise/signals/parameter.py
+++ b/enterprise/signals/parameter.py
@@ -44,6 +44,10 @@ class Parameter(object):
 
         return s
 
+    @property
+    def size(self):
+        return self._size
+
     # this trick lets us pass an instantiated parameter to a signal;
     # the parameter will refuse to be renamed and will return itself
     def __call__(self, name):

--- a/enterprise/signals/parameter.py
+++ b/enterprise/signals/parameter.py
@@ -29,13 +29,13 @@ class Parameter(object):
     def sample(self, n=1, random_state=None):
         if self._size is None:
             s = self._prior.sample(n, random_state)
-            
             if n == 1:
                 s = float(s)
         else:
             if random_state is None:
                 if n > 1:
-                    s = self._prior.sample(n * self._size).reshape((n,self._size))
+                    s = self._prior.sample(n * self._size).reshape(
+                        (n,self._size))
                 else:
                     s = self._prior.sample(self._size)
             else:
@@ -113,5 +113,5 @@ def Normal(mu=0, sigma=1, size=None):
 def Constant(val=None):
     class Constant(ConstantParameter):
         value = val
-    
+
     return Constant

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -525,7 +525,7 @@ def SignalCollection(metasignals):
                     self.white_params.extend(signal.ndiag_params)
                 elif signal.signal_type in ['basis', 'common basis']:
                     self.basis_params.extend(signal.basis_params)
-                elif signal.signal_type == 'delay':
+                elif signal.signal_type == 'deterministic':
                     self.delay_params.extend(signal.delay_params)
 
         # a candidate for memoization

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -530,6 +530,11 @@ def SignalCollection(metasignals):
                     self.basis_params.extend(signal.basis_params)
                 elif signal.signal_type == 'deterministic':
                     self.delay_params.extend(signal.delay_params)
+                else:
+                    msg = '{} signal type not recognized! Caching '.format(
+                        signal.signal_type)
+                    msg += 'may not work correctly for this signal.'
+                    logger.error(msg)
 
         # a candidate for memoization
         @property

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -157,8 +157,11 @@ class MarginalizedLogLikelihood(object):
             for TNr, TNT, (phiinv, logdet_phi) in zip(TNrs, TNTs, phiinvs):
                 Sigma = TNT + np.diag(phiinv)
 
-                cf = sl.cho_factor(Sigma)
-                expval = sl.cho_solve(cf, TNr)
+                try:
+                    cf = sl.cho_factor(Sigma)
+                    expval = sl.cho_solve(cf, TNr)
+                except:
+                    return -np.inf
 
                 logdet_sigma = np.sum(2 * np.log(np.diag(cf[0])))
 

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -64,6 +64,17 @@ class Signal(object):
         return [par for par in self._params.values() if not
                 isinstance(par, ConstantParameter)]
 
+    @property
+    def param_names(self):
+        ret = []
+        for p in self.params:
+            if p.size > 1:
+                for ii in range(0, p.size):
+                    ret.append(p.name+'_{}'.format(ii))
+            else:
+                ret.append(p.name)
+        return ret
+
     def get(self, parname, params={}):
         try:
             return params[self._params[parname].name]
@@ -193,6 +204,17 @@ class PTA(object):
         return sorted({par for signalcollection in self._signalcollections for
                        par in signalcollection.params},
                       key=lambda par: par.name)
+
+    @property
+    def param_names(self):
+        ret = []
+        for p in self.params:
+            if p.size > 1:
+                for ii in range(0, p.size):
+                    ret.append(p.name+'_{}'.format(ii))
+            else:
+                ret.append(p.name)
+        return ret
 
     def get_TNr(self, params):
         return [signalcollection.get_TNr(params) for signalcollection
@@ -488,7 +510,13 @@ class PTA(object):
             return phivecs
 
     def map_params(self, xs):
-        return {par.name: x for par, x in zip(self.params, xs)}
+        ret = {}
+        ct = 0
+        for p in self.params:
+            n = p.size if p.size else 1
+            ret[p.name] = xs[ct:ct+n] if n > 1 else float(xs[ct])
+            ct += n
+        return ret
 
     def get_lnprior(self, xs):
         # map parameter vector if needed
@@ -541,6 +569,17 @@ def SignalCollection(metasignals):
         def params(self):
             return sorted({param for signal in self._signals for param
                            in signal.params}, key=lambda par: par.name)
+
+        @property
+        def param_names(self):
+            ret = []
+            for p in self.params:
+                if p.size > 1:
+                    for ii in range(0, p.size):
+                        ret.append(p.name+'_{}'.format(ii))
+                else:
+                    ret.append(p.name)
+            return ret
 
         def set_default_params(self, params):
             for signal in self._signals:

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -123,7 +123,8 @@ def createfourierdesignmatrix_dm(toas, freqs, nmodes=30, Tspan=None,
 
     # compute the DM-variation vectors
     # TODO: should we use a different normalization
-    Dm = 1.0/(const.DM_K * freqs**2 * 1e12)
+    #Dm = 1.0/(const.DM_K * freqs**2 * 1e12)
+    Dm = (1400/freqs)**2
 
     return F * Dm[:, None], Ffreqs
 

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -70,7 +70,7 @@ def MeasurementNoise(efac=parameter.Uniform(0.5,1.5),
     BaseClass = WhiteNoise(varianceFunction, selection=selection)
 
     class MeasurementNoise(BaseClass):
-        signal_type = 'white_noise'
+        signal_type = 'white noise'
         signal_name = 'efac'
 
     return MeasurementNoise
@@ -89,7 +89,7 @@ def EquadNoise(log10_equad=parameter.Uniform(-10,-5),
     BaseClass = WhiteNoise(varianceFunction, selection=selection)
 
     class EquadNoise(BaseClass):
-        signal_type = 'white_noise'
+        signal_type = 'white noise'
         signal_name = 'equad'
 
     return EquadNoise

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -16,18 +16,31 @@ from enterprise.signals import selections
 from enterprise.signals.selections import Selection
 
 
-def MeasurementNoise(efac=parameter.Uniform(0.5,1.5),
-                     selection=Selection(selections.no_selection)):
-    """Class factory for EFAC type measurement noise."""
+def WhiteNoise(varianceFunction,
+               selection=Selection(selections.no_selection),
+               name=''):
+    """ Class factory for generic white noise signals."""
 
-    class MeasurementNoise(base.Signal):
+    class WhiteNoise(base.Signal):
         signal_type = 'white noise'
-        signal_name = 'efac'
+        signal_name = name
 
         def __init__(self, psr):
 
+            self._do_selection(psr, varianceFunction, selection)
+
+        def _do_selection(self, psr, vfn, selection):
+
             sel = selection(psr)
-            self._params, self._ndiag = sel('efac', efac, psr.toaerrs**2)
+            self._keys = list(sorted(sel.masks.keys()))
+            self._masks = [sel.masks[key] for key in self._keys]
+            self._ndiag, self._params = {}, {}
+            for key, mask in zip(self._keys, self._masks):
+                pnames = [psr.name, name, key]
+                pname = '_'.join([n for n in pnames if n])
+                self._ndiag[key] = vfn(pname, psr=psr)
+                for param in list(self._ndiag[key]._params.values()):
+                    self._params[param.name] = param
 
         @property
         def ndiag_params(self):
@@ -36,39 +49,48 @@ def MeasurementNoise(efac=parameter.Uniform(0.5,1.5),
 
         @base.cache_call('ndiag_params')
         def get_ndiag(self, params):
-            ret = base.ndarray_alt(np.sum(
-                [self.get(p, params)**2*self._ndiag[p]
-                 for p in self._params], axis=0))
-            return ret
+            ret = 0
+            for key, mask in zip(self._keys, self._masks):
+                ret += self._ndiag[key](params=params) * mask
+            return base.ndarray_alt(ret)
+
+    return WhiteNoise
+
+
+@base.function
+def efac_ndiag(toaerrs, efac=1.0):
+    return efac**2 * toaerrs**2
+
+
+def MeasurementNoise(efac=parameter.Uniform(0.5,1.5),
+                     selection=Selection(selections.no_selection)):
+    """Class factory for EFAC type measurement noise."""
+
+    varianceFunction = efac_ndiag(efac=efac)
+    BaseClass = WhiteNoise(varianceFunction, selection=selection)
+
+    class MeasurementNoise(BaseClass):
+        signal_type = 'white_noise'
+        signal_name = 'efac'
 
     return MeasurementNoise
+
+
+@base.function
+def equad_ndiag(toas, log10_equad=-8):
+    return np.ones_like(toas) * 10**(2*log10_equad)
 
 
 def EquadNoise(log10_equad=parameter.Uniform(-10,-5),
                selection=Selection(selections.no_selection)):
     """Class factory for EQUAD type measurement noise."""
 
-    class EquadNoise(base.Signal):
-        signal_type = 'white noise'
+    varianceFunction = equad_ndiag(log10_equad=log10_equad)
+    BaseClass = WhiteNoise(varianceFunction, selection=selection)
+
+    class EquadNoise(BaseClass):
+        signal_type = 'white_noise'
         signal_name = 'equad'
-
-        def __init__(self,psr):
-
-            sel = selection(psr)
-            self._params, self._ndiag = sel('log10_equad', log10_equad,
-                                            np.ones_like(psr.toaerrs))
-
-        @property
-        def ndiag_params(self):
-            """Get any varying ndiag parameters."""
-            return [pp.name for pp in self.params]
-
-        @base.cache_call('ndiag_params')
-        def get_ndiag(self, params):
-            ret = base.ndarray_alt(np.sum(
-                [10**(2*self.get(p, params))*self._ndiag[p]
-                 for p in self._params], axis=0))
-            return ret
 
     return EquadNoise
 

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -246,7 +246,7 @@ class TestLikelihood(unittest.TestCase):
         pta1 = signal_base.PTA([m(p) for p in self.psrs])
         pta2 = signal_base.PTA([m2(p) for p in self.psrs])
 
-        params = {p.name: p.sample()[0] for p in pta1.params}
+        params = {p.name: p.sample() for p in pta1.params}
 
         msg = 'Likelihood mismatch between ECORR methods'
         l1 = pta1.get_lnlikelihood(params)


### PR DESCRIPTION
Here are some changes that make this fairly smooth. Here is an example of a free-spectrum setup:

```python
@signal_base.function
def free_spectrum(f, log10_rho=None):
    return np.repeat(10**log10_rho,2) / f[0]

# white noise
efac = parameter.Uniform(0.5, 10)
equad = parameter.Uniform(-10, -5)
ecorr = parameter.Uniform(-10, -5)

# backend selection
selection = selections.Selection(selections.by_backend)

ef = white_signals.MeasurementNoise(efac=efac, selection=selection)
eq = white_signals.EquadNoise(log10_equad=equad, selection=selection)
ec = white_signals.EcorrKernelNoise(log10_ecorr=ecorr, selection=selection)

# red noise
nf = 30
spec = free_spectrum(log10_rho=parameter.Uniform(-20, -10, size=nf))
rn = gp_signals.FourierBasisGP(spec, components=nf)

# timing model
tm = gp_signals.TimingModel()

# combined signal
s = ef + eq + ec + rn + tm
              
# PTA
pta = signal_base.PTA([s(psr)])

# method will give parameter names and vector param names with an _
pta.param_names
[u'B1855+09_430_ASP_efac',
 u'B1855+09_430_ASP_log10_ecorr',
 u'B1855+09_430_ASP_log10_equad',
 u'B1855+09_430_PUPPI_efac',
 u'B1855+09_430_PUPPI_log10_ecorr',
 u'B1855+09_430_PUPPI_log10_equad',
 u'B1855+09_L-wide_ASP_efac',
 u'B1855+09_L-wide_ASP_log10_ecorr',
 u'B1855+09_L-wide_ASP_log10_equad',
 u'B1855+09_L-wide_PUPPI_efac',
 u'B1855+09_L-wide_PUPPI_log10_ecorr',
 u'B1855+09_L-wide_PUPPI_log10_equad',
 u'B1855+09_log10_rho_0',
 u'B1855+09_log10_rho_1',
 u'B1855+09_log10_rho_2',
 u'B1855+09_log10_rho_3',
 u'B1855+09_log10_rho_4',
 u'B1855+09_log10_rho_5',
 u'B1855+09_log10_rho_6',
 u'B1855+09_log10_rho_7',
 u'B1855+09_log10_rho_8',
 u'B1855+09_log10_rho_9',
 u'B1855+09_log10_rho_10',
 u'B1855+09_log10_rho_11',
 u'B1855+09_log10_rho_12',
 u'B1855+09_log10_rho_13',
 u'B1855+09_log10_rho_14',
 u'B1855+09_log10_rho_15',
 u'B1855+09_log10_rho_16',
 u'B1855+09_log10_rho_17',
 u'B1855+09_log10_rho_18',
 u'B1855+09_log10_rho_19',
 u'B1855+09_log10_rho_20',
 u'B1855+09_log10_rho_21',
 u'B1855+09_log10_rho_22',
 u'B1855+09_log10_rho_23',
 u'B1855+09_log10_rho_24',
 u'B1855+09_log10_rho_25',
 u'B1855+09_log10_rho_26',
 u'B1855+09_log10_rho_27',
 u'B1855+09_log10_rho_28',
 u'B1855+09_log10_rho_29']

# vector or values for samplers
xs = np.hstack(p.sample() for p in pta.params)

# dictionary of key: value pairs
params = {p.name: p.sample() for p in pta.params}

# both of these will work
pta.get_lnlikelihood(xs)
pta.get_lnlikelihood(params)


```