### PR TITLE
PR166 kwarg order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.12.0,<1.14.0
-scipy>=0.18.1
+numpy>=1.14.1
+scipy>=1.1.0
 ephem>=3.7.6.0
 Cython>=0.25.2
 scikit-sparse==0.4.2

--- a/tests/test_hierarchical_parameter.py
+++ b/tests/test_hierarchical_parameter.py
@@ -10,7 +10,6 @@ Tests for hierarchical parameter functionality
 
 from __future__ import division
 
-import math
 import unittest
 
 import numpy as np
@@ -111,7 +110,7 @@ class TestHierarchicalParameter(unittest.TestCase):
                            np.array([1e-16,4e-16,9e-16]))
 
         def log10(A=10**-16):
-            return math.log10(A)
+            return np.log10(A)
 
         log10f = parameter.Function(log10,
                                     A=parameter.Uniform(10**-17,10**-14))
@@ -133,7 +132,7 @@ class TestHierarchicalParameter(unittest.TestCase):
             return (10**log10_A) * f**2
 
         def log10(A=10**-16):
-            return math.log10(A)
+            return np.log10(A)
 
         fquad = white_signals.EquadNoise(log10_equad=parameter.Function(
             log10, A=parameter.Uniform(10**-17,10**-14)))

--- a/tests/test_hierarchical_parameter.py
+++ b/tests/test_hierarchical_parameter.py
@@ -38,8 +38,10 @@ class TestHierarchicalParameter(unittest.TestCase):
 
         x1 = x('x1')
 
+        repr_A = 'x1:Uniform(pmin=0, pmax=1)'
+        repr_B = 'x1:Uniform(pmax=1, pmin=0)'
         assert isinstance(x1,parameter.Parameter)
-        assert str(x1) == 'x1:Uniform(pmin=0, pmax=1)'
+        assert str(x1) == repr_A or str(x1) == repr_B
         assert x1.get_logpdf(0.5) == 0
 
     def test_enterprise_Function(self):
@@ -53,8 +55,10 @@ class TestHierarchicalParameter(unittest.TestCase):
 
         f1 = f('f1')
 
+        repr_A = 'f1(f1_x:Uniform(pmin=0, pmax=1))'
+        repr_B = 'f1(f1_x:Uniform(pmax=1, pmin=0))'
         assert isinstance(f1,parameter.FunctionBase)
-        assert str(f1) == 'f1(f1_x:Uniform(pmin=0, pmax=1))'
+        assert str(f1) == repr_A or str(f1) == repr_B
         assert len(f1.params) == 1
         assert f1(2) == 5
         assert f1(2,0.5,7) == 9.5
@@ -74,10 +78,12 @@ class TestHierarchicalParameter(unittest.TestCase):
 
         g1 = g('g1')
 
+        repr_A = 'g1_w:Uniform(pmin=2, pmax=3)'
+        repr_B = 'g1_w:Uniform(pmax=3, pmin=2)'
         assert isinstance(g1,parameter.FunctionBase)
 
-        assert (sorted(map(str,g1.params))[0] ==
-                'g1_w:Uniform(pmin=2, pmax=3)')
+        assert (sorted(map(str,g1.params))[0] == repr_A or
+                sorted(map(str,g1.params))[0] == repr_B)
 
         assert g1(2,z=3) == 12
         assert g1(2,w=10,z=3) == 60
@@ -92,7 +98,9 @@ class TestHierarchicalParameter(unittest.TestCase):
 
         pl1 = pl('pl1')
 
-        assert str(pl1) == 'pl1(pl1_log10_A:Uniform(pmin=0, pmax=5))'
+        repr_A = 'pl1(pl1_log10_A:Uniform(pmin=0, pmax=5))'
+        repr_B = 'pl1(pl1_log10_A:Uniform(pmax=5, pmin=0))'
+        assert str(pl1) == repr_A or str(pl1) == repr_B
 
         fs = np.array([1,2,3])
 
@@ -111,8 +119,9 @@ class TestHierarchicalParameter(unittest.TestCase):
 
         pm1 = pm('pm1')
 
-        assert (str(pm1) ==
-                'pm1(pm1_log10_A_A:Uniform(pmin=1e-17, pmax=1e-14))')
+        repr_A = 'pm1(pm1_log10_A_A:Uniform(pmin=1e-17, pmax=1e-14))'
+        repr_B = 'pm1(pm1_log10_A_A:Uniform(pmax=1e-14, pmin=1e-17))'
+        assert str(pm1) == repr_A or str(pm1) == repr_B
 
         assert np.allclose(pm1(fs, log10_A=-13),
                            np.array([1e-13,4e-13,9e-13]))
@@ -131,8 +140,9 @@ class TestHierarchicalParameter(unittest.TestCase):
 
         fquad1 = fquad(self.psr)
 
-        assert (str(fquad1.params) ==
-                '[B1855+09_log10_equad_A:Uniform(pmin=1e-17, pmax=1e-14)]')
+        repr_A = '[B1855+09_log10_equad_A:Uniform(pmin=1e-17, pmax=1e-14)]'
+        repr_B = '[B1855+09_log10_equad_A:Uniform(pmax=1e-14, pmin=1e-17)]'
+        assert str(fquad1.params) == repr_A or str(fquad1.params) == repr_B
         assert np.allclose(fquad1.get_ndiag(
             params={'B1855+09_log10_equad_A': 10**-14})[:3],
             np.array([1e-28,1e-28,1e-28]))


### PR DESCRIPTION
This implements my "option 2": leave `_argrepr` alone and check both orders in `test_hierarchical_parameter.py`.  This means `Py3.6+` will have the string representations in the expected order, but older versions may not.

* fixes failing tests
* bump requirements: `numpy>=1.14.1`, `scipy>=1.1.0`
*  one more standardize import: prefer `numpy` to `math`